### PR TITLE
Add base support for background and button in Safari extension

### DIFF
--- a/lib/safari/Info.plist
+++ b/lib/safari/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>{{author}}</string>
 	<key>Builder Version</key>
-	<string>10601.2.7.2</string>
+	<string>10601.7.7</string>
 	<key>CFBundleDisplayName</key>
 	<string>{{name}}</string>
 	<key>CFBundleIdentifier</key>
@@ -15,9 +15,37 @@
 	<key>CFBundleShortVersionString</key>
 	<string>{{version}}</string>
 	<key>CFBundleVersion</key>
-	<string>{{version}}</string>
+	<string>1</string>
+	<key>DeveloperIdentifier</key>
+	<string>{{developer_identifier}}</string>
+	<key>Chrome</key>
+	<dict>
+		<key>Database Quota</key>
+		<integer>1048576</integer>
+		{{#if background.scripts}}
+		<key>Global Page</key>
+		<string>background.html</string>
+		{{/if}}
+		{{#if page_action }}
+		<key>Toolbar Items</key>
+		<array>
+			<dict>
+				<key>Command</key>
+				<string>{{page_action.callback}}</string>
+				<key>Identifier</key>
+				<string>{{page_action.id}}</string>
+				<key>Image</key>
+				<string>{{page_action.default_icon}}</string>
+				<key>Include By Default</key>
+				<true/>
+				<key>Label</key>
+				<string>{{page_action.default_title}}</string>
+			</dict>
+		</array>
+		{{/if}}
+	</dict>
+    {{#if content_scripts}}
 	<key>Content</key>
-{{#if content_scripts}}
 	<dict>
 		<key>Scripts</key>
 		{{#if content_scripts.js}}
@@ -41,21 +69,17 @@
 		</dict>
 		{{/if}}
 	</dict>
-{{/if}}
+    {{/if}}
 	<key>ExtensionInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>Permissions</key>
 	<dict>
 		<key>Website Access</key>
 		<dict>
-			<key>Allowed Domains</key>
-			<array>
-				<string>{{host}}</string>
-			</array>
 			<key>Include Secure Pages</key>
 			<true/>
 			<key>Level</key>
-			<string>Some</string>
+			<string>All</string>
 		</dict>
 	</dict>
 </dict>

--- a/lib/safari/Settings.plist
+++ b/lib/safari/Settings.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>

--- a/lib/safari/background.html
+++ b/lib/safari/background.html
@@ -1,0 +1,21 @@
+{{#each background.scripts}}
+<script src="{{this}}">
+</script>
+{{/each}}
+<script>
+{{#if homepage_url}}
+// Default callback for homepageRedirect
+function homepageRedirec(){
+    safari.application.activeBrowserWindow.activeTab.url = "{{homepage_url}}";
+}
+{{/if}}
+{{#if page_action}}
+
+// Page action button
+safari.application.addEventListener("command", function(event){
+    if(event.command == "{{page_action.callback}}"){
+        {{#if page_action.callback}}{{page_action.callback}}();{{/if}}
+    }
+}, false);
+{{/if}}
+</script>

--- a/tasks/lib/browser-extension.js
+++ b/tasks/lib/browser-extension.js
@@ -50,7 +50,9 @@ var browserExtension = function(root, options, target) {
             'lib/index.js'
         ],
         safari: [
-            'Info.plist'
+            'Info.plist',
+            'Settings.plist',
+            'background.html'
         ]
     };
     this.browserDestineFiles = {

--- a/test/browser_extension_test.js
+++ b/test/browser_extension_test.js
@@ -24,10 +24,12 @@ exports.browser_extension = {
         test.done();
     },
     test_files_builded: function(test) {
-        test.expect(3);
+        test.expect(5);
         test.ok(grunt.file.isFile('build/default/firefox/com.browser.extension.xpi'));
         test.ok(grunt.file.isFile('build/default/ie/setup.exe'));
         test.ok(grunt.file.isFile('build/default/safari.safariextension/Info.plist'));
+        test.ok(grunt.file.isFile('build/default/safari.safariextension/Settings.plist'));
+        test.ok(grunt.file.isFile('build/default/safari.safariextension/background.html'));
         test.done();
     },
     test_icons_builded: function(test) {


### PR DESCRIPTION
Added base support for Safari extension with scripts in background, the API with browser is different of Chrome/Opera and Firefox, need use ```safai.``` API.